### PR TITLE
Create secrets similar to "kubectl create secret tls", daily renewals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
-FROM debian:8.1
+FROM alpine:3.4
 MAINTAINER Christian Hoffmeister <mail@choffmeister.de>
 
-RUN \
-  apt-get update && \
-  apt-get install ---yes git wget && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk add --no-cache --update wget bash certbot ca-certificates
 
 RUN \
-  git clone https://github.com/certbot/certbot /opt/certbot && \
-  ln -s /opt/certbot/letsencrypt-auto /usr/local/bin/letsencrypt-auto && \
-  letsencrypt-auto; exit 0
+  wget https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+  chmod +x /usr/local/bin/kubectl
 
-RUN \
-  wget https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubectl && \
-  chmod +x kubectl && \
-  mv kubectl /usr/local/bin
+WORKDIR /opt/certbot
 
-WORKDIR /opt/kubernetes-certbot
 COPY run.sh ./run.sh
+COPY wait_and_renew.sh ./wait_and_renew.sh
+COPY renew_certs.sh ./renew_certs.sh
 
 EXPOSE 80
-CMD sleep 86400
+CMD ["./wait_and_renew.sh"]

--- a/README.md
+++ b/README.md
@@ -5,57 +5,75 @@ Uses [certbot][certbot] to obtain an X.509 certificate from [Let's encrypt][lets
 
 ## Usage
 
-Create a service:
+Create a configmap for your secret -> domains mapping:
 
-```yml
-# kubernetes-certbot-svc.yml
+```yaml
+---
+kind: ConfigMap
 apiVersion: v1
-kind: Service
 metadata:
-  name: kubernetes-certbot
-spec:
-  selector:
-    name: kubernetes-certbot
-  ports:
-    - name: http
-      port: 80
+  name: letsencrypt-ssl-certificates
+data:
+  ssl-certifcates.properties: |
+    some-secret-name=example.com,www.example.com
 ```
 
-Create a replication controller:
+Create a deployment for certbot (fill in your email and consider allocating secure persistant storage for the
+letsencrypt-data volume):
 
 ```yml
-# kubernetes-certbot-rc.yml
-apiVersion: v1
-kind: ReplicationController
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: kubernetes-certbot
+  labels:
+    app: kubernetes-certbot
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        name: kubernetes-certbot
+        app: kubernetes-certbot
     spec:
       containers:
-      - name: kubernetes-certbot
-        image: choffmeister/kubernetes-certbot:latest
-        imagePullPolicy: Always
-        env:
-          - name: SECRET_NAMESPACE
-            value: default
-          - name: SECRET_NAME_PREFIX
-            value: foobar
-        volumeMounts:
-        - mountPath: /etc/letsencrypt
-          name: letsencrypt-data
+        - name: certbot
+          image: choffmeister/kubernetes-certbot:latest
+          imagePullPolicy: Always
+          env:
+            - name: SECRET_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LETS_ENCRYPT_EMAIL
+              # TODO: Provide an email for let's encrypt.
+              value: fill-this-in@example.com
+          volumeMounts:
+            - mountPath: /etc/letsencrypt
+              name: letsencrypt-data
+            - mountPath: /etc/letsencrypt-certs
+              name: letsencrypt-certs-config
       volumes:
-      - name: letsencrypt-data
-        emptyDir: {}
+        - name: letsencrypt-data
+          # TODO: Consider using real, secure storage on your cluster.
+          emptyDir: {}
+        - name: letsencrypt-certs-config
+          configMap:
+            name: letsencrypt-ssl-certificates
 ```
 
-Configure your front gateway (in this example [nginx][nginx]) to forward all incoming traffic for certbot to the service
-you just created (this assumes, you have [kube-dns][kubedns] running, so that nginx is able to resolve the host
-`kubernetes-certbot`):
+Create a service:
+
+```shell
+kubectl expose deployment kubernetes-certbot --port=80
+```
+
+Configure your front gateway, and point your DNS at the gateway, if you haven't already. Examples below; these assume
+you have [kube-dns][kubedns] running, so that nginx is able to resolve the host `kubernetes-certbot`):
+
+### Example: [straight nginx][nginx]
+
+ To forward all incoming traffic for certbot to the service:
 
 ```
 # nginx.conf
@@ -69,17 +87,53 @@ server {
 }
 ```
 
-Then, whenever you need a certificate, find out the name of the pod (let it be `${LETSENCRYPT_POD}` here) and execute:
+### Example: [ingress-controller][ingress-controller]
 
-```bash
-kubectl exec -it ${LETSENCRYPT_POD} -- bash ./run.sh "secret-name" "mail@mydomain.com" "mydomain.com,www.mydomain.com"
+You'll want to use add a route to your host:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: certbot-ingress
+  annotations:
+    # Needed if your ingress controller forces SSL redirects
+    ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /.well-known/acme-challenge/
+            backend:
+              serviceName: kubernetes-certbot
+              servicePort: 80
+    - host: www.example.com
+      http:
+        paths:
+          - path: /.well-known/acme-challenge/
+            backend:
+              serviceName: kubernetes-certbot
+              servicePort: 80
 ```
 
-This will create a secret `foobar-secret-name` in the namespace `default` containing four entries for the individual
-`.pem` files genereted by certbot.
+## And done
+
+And that should work; the next time the certbot runs, it will create the secret "some-secret-name" for those hosts. The
+certbot checks once every day if it needs to renew your certificates, and creates and/or updates the appropriate secrets;
+if using the nginx-ingress-controller it should reload the config when the secrets change.
+
+## Manual renew run:
+
+If you don't want to wait the initial 5 minutes, or you want to retry, you can run the cert generation with:
+
+```shell
+kubectl exec $(kubectl get pods -l app=kubernetes-certbot --output=jsonpath={.items..metadata.name}) -- ./renew_certs.sh
+```
 
 [letsencrypt]: https://letsencrypt.org/
 [certbot]: https://github.com/certbot/certbot
 [kubernetes]: http://kubernetes.io/
 [nginx]: https://nginx.org/
 [kubedns]: https://github.com/kubernetes/kubernetes/tree/master/build/kube-dns
+[ingress-controller]: https://github.com/kubernetes/contrib/tree/master/ingress/controllers

--- a/renew_certs.sh
+++ b/renew_certs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eux
+
+while IFS='=' read -r secret_name domains
+do
+    ./run.sh $secret_name $domains
+done < /etc/letsencrypt-certs/ssl-certifcates.properties

--- a/run.sh
+++ b/run.sh
@@ -1,25 +1,25 @@
-#/bin/bash -e
+#!/bin/bash
 
-EMAIL="${2}"
-DOMAINS="${3}"
-DOMAIN_MAIN="$(echo $DOMAINS | sed 's/,.*//')"
-SECRET_NAMESPACE="${SECRET_NAMESPACE:-default}"
-SECRET_NAME_PREFIX="${SECRET_NAME_PREFIX:-letsencrypt}"
-SECRET_NAME="${SECRET_NAME_PREFIX}-${1}"
+set -eu
 
-echo "Generating certificate ${DOMAIN}"
-letsencrypt-auto \
+readonly SECRET_NAME=$1
+readonly DOMAINS=$2
+readonly DOMAIN_MAIN=$(echo $DOMAINS | sed 's/,.*//')
+readonly SECRET_NAMESPACE=${SECRET_NAMESPACE:-default}
+
+echo "Generating certificate ${DOMAIN_MAIN}"
+certbot \
   --non-interactive \
   --agree-tos \
   --standalone \
   --standalone-supported-challenges http-01 \
-  --http-01-port 80 \
-  --email "${EMAIL}" \
+  --email "${LETS_ENCRYPT_EMAIL}" \
   --domains "${DOMAINS}" \
   certonly
 
 echo "Generating kubernetes secret ${SECRET_NAME} (namespace ${SECRET_NAMESPACE})"
-(cat << EOF
+
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -27,10 +27,6 @@ metadata:
   namespace: "${SECRET_NAMESPACE}"
 type: Opaque
 data:
-  cert.pem: "$(cat /etc/letsencrypt/live/${DOMAIN_MAIN}/cert.pem | base64 --wrap=0)"
-  chain.pem: "$(cat /etc/letsencrypt/live/${DOMAIN_MAIN}/chain.pem | base64 --wrap=0)"
-  fullchain.pem: "$(cat /etc/letsencrypt/live/${DOMAIN_MAIN}/fullchain.pem | base64 --wrap=0)"
-  privkey.pem: "$(cat /etc/letsencrypt/live/${DOMAIN_MAIN}/privkey.pem | base64 --wrap=0)"
+  tls.crt: "$(cat /etc/letsencrypt/live/${DOMAIN_MAIN}/fullchain.pem | base64 | tr -d '\n')"
+  tls.key: "$(cat /etc/letsencrypt/live/${DOMAIN_MAIN}/privkey.pem | base64 | tr -d '\n')"
 EOF
-) > "${SECRET_NAMESPACE}-${SECRET_NAME}.yml"
-kubectl apply -f "${SECRET_NAMESPACE}-${SECRET_NAME}.yml"

--- a/wait_and_renew.sh
+++ b/wait_and_renew.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eux
+
+while true; do
+    # Sleep 5 minutes so a crash looping pod doesn't punch let's encrypt.
+    echo "Renewing cert in 5 minutes"
+    sleep 300
+    ./renew_certs.sh
+    echo "Certs renewed; see you tomorrow"
+    sleep 86100
+done


### PR DESCRIPTION
Hello!

This was a pretty neat integration. I hacked around on it to make it work for for the nginx-ingress-controller; I'm not sure it fits your usecase anymore but I thought I'd see if you wanted the changes.

Major changes:

1. Changed the secret format to the same as "kubectl create secret tls"; which is what the ingress controller uses
1. Set the CMD of the docker file to check for renewals every 24 hours so you don't need to manually run the update.
1. Changed the list of certificates to renew to be in a ConfigMap
1. Changed the base image to alpine for a smaller image
1. Removed SECRET_NAME_PREFIX in preference of being explicit in config map
1. Set EMAIL in the deployment so the auto renew works.